### PR TITLE
Fix for AuthUserFile not specified

### DIFF
--- a/apache/git/templates/redmine_git.conf.j2
+++ b/apache/git/templates/redmine_git.conf.j2
@@ -18,6 +18,7 @@ ScriptAlias {{ redmine_apache_git_url_path }}/ {{ redmine_apache_git_backend }}/
 
   AuthType Basic
   AuthName "{{ redmine_apache_git_auth_name }}"
+  AuthUserFile /dev/null
   Require valid-user
 
   PerlAccessHandler {{ REDMINE_APACHE_AUTH_PERL_PACKAGE }}::access_handler

--- a/apache/subversion/templates/redmine_subversion.conf.j2
+++ b/apache/subversion/templates/redmine_subversion.conf.j2
@@ -10,6 +10,7 @@ RequestHeader edit Destination ^https http early
 
   AuthType Basic
   AuthName "{{ redmine_apache_subversion_auth_name }}"
+  AuthUserFile /dev/null
   Require valid-user
 
   LimitXMLRequestBody 0


### PR DESCRIPTION
Apache started to complain. SourceTree will not trigger the proper login prompt.

Fixed for Git and Subversion.